### PR TITLE
feat: Detect Pull Request Builds

### DIFF
--- a/src/SharedBuild.Test/Mocks/FakeArguments.cs
+++ b/src/SharedBuild.Test/Mocks/FakeArguments.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+
+namespace Grynwald.SharedBuild.Test.Mocks
+{
+    internal class FakeArguments : ICakeArguments
+    {
+        public ICollection<string> GetArguments(string name) => Array.Empty<string>();
+
+        public IDictionary<string, ICollection<string>> GetArguments() => throw new NotImplementedException();
+
+        public bool HasArgument(string name) => throw new NotImplementedException();
+    }
+}

--- a/src/SharedBuild.Test/Mocks/FakeCakeContext.cs
+++ b/src/SharedBuild.Test/Mocks/FakeCakeContext.cs
@@ -24,9 +24,15 @@ namespace Grynwald.SharedBuild.Test.Mocks
 
         public IGlobber Globber => throw new System.NotImplementedException();
 
-        public ICakeLog Log => throw new System.NotImplementedException();
+        /// <summary>
+        /// Mock object for <see cref="ICakeContext.Log"/>
+        /// </summary>
+        public FakeLog Log { get; }
 
-        public ICakeArguments Arguments => throw new System.NotImplementedException();
+        /// <summary>
+        /// Mock object for <see cref="ICakeContext.Arguments"/>
+        /// </summary>
+        public FakeArguments Arguments { get; }
 
         /// <summary>
         /// Mock object for <see cref="ICakeContext.ProcessRunner" />
@@ -56,12 +62,21 @@ namespace Grynwald.SharedBuild.Test.Mocks
         /// <inheritdoc />
         IToolLocator ICakeContext.Tools => Tools;
 
+        /// <inheritdoc />
+        ICakeLog ICakeContext.Log => Log;
+
+        /// <inheritdoc />
+        ICakeArguments ICakeContext.Arguments => Arguments;
+
+
         public FakeCakeContext()
         {
             Environment = FakeEnvironment.CreateWindowsEnvironment();
             FileSystem = new FakeFileSystem(Environment);
             ProcessRunner = new FakeProcessRunner();
             Tools = new FakeToolLocator();
+            Log = new FakeLog();
+            Arguments = new FakeArguments();
         }
     }
 }

--- a/src/SharedBuild.Test/_Context/_Default/DefaultBuildContextTest.GitHub.PullRequest.cs
+++ b/src/SharedBuild.Test/_Context/_Default/DefaultBuildContextTest.GitHub.PullRequest.cs
@@ -1,0 +1,67 @@
+﻿using Grynwald.SharedBuild.Test.Mocks;
+using Xunit;
+
+namespace Grynwald.SharedBuild.Test
+{
+    /// <summary>
+    /// Tests for <see cref="DefaultGitHubPullRequestContext"/>
+    /// </summary>
+    public partial class DefaultBuildContextTest
+    {
+        public class GitHub
+        {
+            public class PullRequest
+            {
+                [Theory]
+                [InlineData(null, null, null, false)]
+                [InlineData("true", null, null, false)]
+                [InlineData("true", "0", null, false)]
+                [InlineData("true", "23", null, false)]
+                [InlineData("true", "23", "TfsGit", false)]
+                [InlineData("true", "23", "GitHub", true)]
+                public void IsPullRequest_returns_expected_value_when_building_a_GitHub_PR_on_Azure_Pipelines(string tfBuild, string system_PullRequest_PullRequestId, string build_Repository_Provider, bool expected)
+                {
+                    // ARRANGE
+                    var context = new FakeCakeContext();
+                    context.Environment.SetEnvironmentVariable("TF_BUILD", tfBuild);
+                    context.Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", system_PullRequest_PullRequestId);
+                    context.Environment.SetEnvironmentVariable("BUILD_REPOSITORY_PROVIDER", build_Repository_Provider);
+
+                    var sut = new DefaultBuildContext(context);
+
+                    // ACT 
+                    var isPullRequest = sut.GitHub.PullRequest.IsPullRequest;
+
+                    // ASSERT
+                    Assert.Equal(expected, isPullRequest);
+                }
+
+                [Theory]
+                [InlineData(null, null, null, null, 0)]
+                [InlineData("true", null, null, null, 0)]
+                [InlineData("true", "0", null, null, 0)]
+                [InlineData("true", "23", null, null, 0)]
+                [InlineData("true", "23", "TfsGit", null, 0)]
+                [InlineData("true", "23", "GitHub", "42", 42)]
+                public void PullRequestNumber_returns_expected_value(string tfBuild, string system_PullRequest_PullRequestId, string build_Repository_Provider, string system_PullRequest_PullRequestNumber, int expected)
+                {
+
+                    // ARRANGE
+                    var context = new FakeCakeContext();
+                    context.Environment.SetEnvironmentVariable("TF_BUILD", tfBuild);
+                    context.Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", system_PullRequest_PullRequestId);
+                    context.Environment.SetEnvironmentVariable("BUILD_REPOSITORY_PROVIDER", build_Repository_Provider);
+                    context.Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", system_PullRequest_PullRequestNumber);
+
+                    var sut = new DefaultBuildContext(context);
+
+                    // ACT 
+                    var prNumber = sut.GitHub.PullRequest.Number;
+
+                    // ASSERT
+                    Assert.Equal(expected, prNumber);
+                }
+            }
+        }
+    }
+}

--- a/src/SharedBuild/_Context/IGitHubContext.cs
+++ b/src/SharedBuild/_Context/IGitHubContext.cs
@@ -18,6 +18,11 @@
         string RepositoryName { get; }
 
         /// <summary>
+        /// Gets information about the Pull Request being built
+        /// </summary>
+        IGitHubPullRequestContext PullRequest { get; }
+
+        /// <summary>
         /// Tries to get the GitHub Access token for the current builds
         /// </summary>
         string? TryGetAccessToken();

--- a/src/SharedBuild/_Context/IGitHubPullRequestContext.cs
+++ b/src/SharedBuild/_Context/IGitHubPullRequestContext.cs
@@ -1,0 +1,15 @@
+﻿namespace Grynwald.SharedBuild
+{
+    public interface IGitHubPullRequestContext : IPrintableObject
+    {
+        /// <summary>
+        /// Determines whether the current build is building a Pull Request
+        /// </summary>
+        bool IsPullRequest { get; }
+
+        /// <summary>
+        /// Gets the number of the GitHub Pull Request when <see cref="IsPullRequest"/> is <c>true</c>, otherwise returns false.
+        /// </summary>
+        int Number { get; }
+    }
+}

--- a/src/SharedBuild/_Context/_Default/DefaultGitHubContext.cs
+++ b/src/SharedBuild/_Context/_Default/DefaultGitHubContext.cs
@@ -20,11 +20,15 @@ namespace Grynwald.SharedBuild
         /// <inheritdoc />
         public virtual string RepositoryName => m_ProjectInfo.Value.Repository;
 
+        /// <inheritdoc />
+        public IGitHubPullRequestContext PullRequest { get; }
+
 
         public DefaultGitHubContext(DefaultBuildContext context)
         {
             m_Context = context ?? throw new ArgumentNullException(nameof(context));
             m_ProjectInfo = new Lazy<GitHubProjectInfo>(() => GitHubUrlParser.ParseRemoteUrl(m_Context.Git.RemoteUrl));
+            PullRequest = new DefaultGitHubPullRequestContext(context);
         }
 
 
@@ -44,9 +48,13 @@ namespace Grynwald.SharedBuild
         /// <inheritdoc />
         public void PrintToLog(ICakeLog log)
         {
+            var indentedLog = new IndentedCakeLog(log);
+
             log.Information($"{nameof(HostName)}: {HostName}");
             log.Information($"{nameof(RepositoryOwner)}: {RepositoryOwner}");
             log.Information($"{nameof(RepositoryName)}: {RepositoryName}");
+            log.Information($"{nameof(PullRequest)}:");
+            PullRequest.PrintToLog(indentedLog);
         }
     }
 }

--- a/src/SharedBuild/_Context/_Default/DefaultGitHubPullRequestContext.cs
+++ b/src/SharedBuild/_Context/_Default/DefaultGitHubPullRequestContext.cs
@@ -1,0 +1,41 @@
+﻿using Cake.Common.Build.AzurePipelines.Data;
+using Cake.Core.Diagnostics;
+
+namespace Grynwald.SharedBuild
+{
+    public class DefaultGitHubPullRequestContext : IGitHubPullRequestContext
+    {
+        /// <inheritdoc />
+        public bool IsPullRequest { get; }
+
+        /// <inheritdoc />
+        public int Number { get; }
+
+
+        public DefaultGitHubPullRequestContext(DefaultBuildContext context)
+        {
+            //TODO: Can this also be determined when building locally (or on a CI system other than Azure Pipelines)
+            if (context.AzurePipelines.IsActive)
+            {
+                IsPullRequest =
+                    context.AzurePipelines.Environment.Repository.Provider == AzurePipelinesRepositoryType.GitHub &&
+                    context.AzurePipelines.Environment.PullRequest.IsPullRequest;
+
+                Number = context.AzurePipelines.Environment.PullRequest.Number;
+            }
+            else
+            {
+                IsPullRequest = false;
+                Number = 0;
+            }
+        }
+
+
+
+        public void PrintToLog(ICakeLog log)
+        {
+            log.Information($"{nameof(IsPullRequest)}: {IsPullRequest}");
+            log.Information($"{nameof(Number)}: {Number}");
+        }
+    }
+}


### PR DESCRIPTION
Add properties "IBuildContext.GitHub.PullRequest.IsPullRequest" and "IBuildContext.GitHub.PullRequest.Number" that provide information about whether the current build is a Pull Request build and the Pull Request number.
The information is being provided by the Azure Pipelines provider, so it will only be available when running on Azure Pipelines
