### PR TITLE
feat: Add option to customize settings passed to "dotnet test"

### DIFF
--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -39,14 +39,8 @@ namespace Grynwald.SharedBuild.Tasks
             throw exception;
         }
 
-
-        private void RunTests(IBuildContext context)
+        protected virtual DotNetTestSettings GetDotNetTestSettings(IBuildContext context)
         {
-            context.Log.Information($"Running tests for {context.SolutionPath}");
-
-            //
-            // Run tests
-            //
             var testSettings = new DotNetTestSettings()
             {
                 Configuration = context.BuildSettings.Configuration,
@@ -61,6 +55,18 @@ namespace Grynwald.SharedBuild.Tasks
                 // Assumes that the "coverlet.collector" package is installed in all test projects
                 testSettings.Collectors = new[] { "XPlat Code Coverage" };
             }
+
+            return testSettings;
+        }
+
+        private void RunTests(IBuildContext context)
+        {
+            context.Log.Information($"Running tests for {context.SolutionPath}");
+
+            //
+            // Run tests
+            //
+            var testSettings = GetDotNetTestSettings(context);
 
             context.DotNetTest(context.SolutionPath.FullPath, testSettings);
 


### PR DESCRIPTION
Allow customization of the "DotNetTestSettings" passed to "dotnet test" in the "Test" task.

To customize the test settings, create a custom test task derived from "TestTask" and override GetDotNetTestSettings()