### PR TITLE
feat: Skip execution of the "ValidateCodeFormatting" task when build is running on Azure Pipelines

### DIFF
--- a/src/SharedBuild.Test/Mocks/FakeAzurePipelinesContext.cs
+++ b/src/SharedBuild.Test/Mocks/FakeAzurePipelinesContext.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Cake.Common.Build.AzurePipelines;
+using Cake.Common.Build.AzurePipelines.Data;
+using Cake.Core.Diagnostics;
+
+namespace Grynwald.SharedBuild.Test.Mocks
+{
+    internal class FakeAzurePipelinesContext : IAzurePipelinesContext
+    {
+        public IAzurePipelinesArtifactNames ArtifactNames => throw new NotImplementedException();
+
+        public bool IsActive
+        {
+            get => IsRunningOnAzurePipelines;
+            set => IsRunningOnAzurePipelines = value;
+        }
+
+        public bool IsRunningOnAzurePipelines { get; set; }
+
+        public AzurePipelinesEnvironmentInfo Environment => throw new NotImplementedException();
+
+        public IAzurePipelinesCommands Commands => throw new NotImplementedException();
+
+        public void PrintToLog(ICakeLog log)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SharedBuild.Test/Mocks/FakeBuildContext.cs
+++ b/src/SharedBuild.Test/Mocks/FakeBuildContext.cs
@@ -28,7 +28,13 @@ namespace Grynwald.SharedBuild.Test.Mocks
             set => m_SolutionPath = value;
         }
 
-        public IAzurePipelinesContext AzurePipelines => throw new NotImplementedException();
+        /// <summary>
+        /// Gets the mock for <see cref="IBuildContext.AzurePipelines"/>
+        /// </summary>
+        public FakeAzurePipelinesContext AzurePipelines { get; } = new();
+
+        /// <inheritdoc />
+        IAzurePipelinesContext IBuildContext.AzurePipelines => AzurePipelines;
 
         public IBuildSettings BuildSettings => throw new NotImplementedException();
 
@@ -43,7 +49,7 @@ namespace Grynwald.SharedBuild.Test.Mocks
         public IReadOnlyCollection<IPushTarget> PushTargets => throw new NotImplementedException();
 
         /// <summary>
-        /// Mock object for <see cref="IBuildContext.CodeFormattingSettings"/>
+        /// Gets the mock for <see cref="IBuildContext.CodeFormattingSettings"/>
         /// </summary>
         public FakeCodeFormattingSettings CodeFormattingSettings { get; } = new();
 


### PR DESCRIPTION
Running dotnet format on Azure Pipelines when using the .NET 9 SDK and Nerdbank.GitVersioning is installed causes the build to hang (see https://github.com/dotnet/sdk/issues/44951).

To work around this, skip the task when running on Azure Pipelines and emit a warning about the task being skipped
