### PR TITLE
fix: Fix detection of Pull Request builds on Azure Pipelines

### DIFF
--- a/src/SharedBuild.Test/_Context/_Default/DefaultBuildContextTest.GitHub.PullRequest.cs
+++ b/src/SharedBuild.Test/_Context/_Default/DefaultBuildContextTest.GitHub.PullRequest.cs
@@ -19,12 +19,12 @@ public partial class DefaultBuildContextTest
             [InlineData("true", "23", null, false)]
             [InlineData("true", "23", "TfsGit", false)]
             [InlineData("true", "23", "GitHub", true)]
-            public void IsPullRequest_returns_expected_value_when_building_a_GitHub_PR_on_Azure_Pipelines(string? tfBuild, string? system_PullRequest_PullRequestId, string? build_Repository_Provider, bool expected)
+            public void IsPullRequest_returns_expected_value_when_building_a_GitHub_PR_on_Azure_Pipelines(string? tfBuild, string? system_PullRequest_PullRequestNumber, string? build_Repository_Provider, bool expected)
             {
                 // ARRANGE
                 var context = new FakeCakeContext();
                 context.Environment.SetEnvironmentVariable("TF_BUILD", tfBuild);
-                context.Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", system_PullRequest_PullRequestId);
+                context.Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", system_PullRequest_PullRequestNumber);
                 context.Environment.SetEnvironmentVariable("BUILD_REPOSITORY_PROVIDER", build_Repository_Provider);
 
                 var sut = new DefaultBuildContext(context);

--- a/src/SharedBuild/_Context/_Default/DefaultGitHubPullRequestContext.cs
+++ b/src/SharedBuild/_Context/_Default/DefaultGitHubPullRequestContext.cs
@@ -19,7 +19,10 @@ public class DefaultGitHubPullRequestContext : IGitHubPullRequestContext
         {
             IsPullRequest =
                 context.AzurePipelines.Environment.Repository.Provider == AzurePipelinesRepositoryType.GitHub &&
-                context.AzurePipelines.Environment.PullRequest.IsPullRequest;
+                // Do not use context.AzurePipelines.Environment.PullRequest.IsPullRequest, since that returns false since GitHub's PR ids exceeded int.MaxValue
+                // (see https://github.com/cake-build/cake/issues/4410)
+                // Instead, check the precense of a PR number
+                context.AzurePipelines.Environment.PullRequest.Number > 0;
 
             Number = context.AzurePipelines.Environment.PullRequest.Number;
         }


### PR DESCRIPTION
Fix detection if build is a PR build when running on Azure Pipelines.

This is a workaround for cake-build/cake#4410