### PR TITLE
feat: Include Cake.BuildSystems module by default

### DIFF
--- a/src/SharedBuild.Test/packages.lock.json
+++ b/src/SharedBuild.Test/packages.lock.json
@@ -70,6 +70,11 @@
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         }
       },
+      "Cake.BuildSystems.Module": {
+        "type": "Transitive",
+        "resolved": "7.1.0",
+        "contentHash": "/QO0f2S8qZKpO3a5xvXa1kLd0vhJFjC/7h4Qa3VfkY2YdRT0Mxwx9Ky5MbjE0rqGD79XSgT4lxDJU4N/speaQA=="
+      },
       "Cake.Cli": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -476,6 +481,7 @@
       "grynwald.sharedbuild": {
         "type": "Project",
         "dependencies": {
+          "Cake.BuildSystems.Module": "[7.1.0, )",
           "Cake.FileHelpers": "[7.0.0, )",
           "Cake.Frosting": "[5.0.0, )",
           "Cake.GitVersioning": "[3.7.112, )",

--- a/src/SharedBuild/CakeHostExtensions.cs
+++ b/src/SharedBuild/CakeHostExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Cake.AzurePipelines.Module;
 using Cake.Frosting;
+using Cake.GitHubActions.Module;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Grynwald.SharedBuild;
@@ -18,7 +20,9 @@ public static class CakeHostExtensions
     {
         return host
             .UseContext<TContext>()
-            .AddAssembly(typeof(CakeHostExtensions).Assembly, taskFilter);
+            .AddAssembly(typeof(CakeHostExtensions).Assembly, taskFilter)
+            .UseModule<AzurePipelinesModule>()
+            .UseModule<GitHubActionsModule>();
     }
 
     /// <summary>

--- a/src/SharedBuild/Grynwald.SharedBuild.csproj
+++ b/src/SharedBuild/Grynwald.SharedBuild.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Cake.GitVersioning" Version="3.7.112" />
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <PackageReference Include="Cake.BuildSystems.Module" Version="7.1.0" />
   </ItemGroup>
 
   <!-- Cake.GitHub (currently pulled in via git submodules instead of NuGet) -->

--- a/src/SharedBuild/packages.lock.json
+++ b/src/SharedBuild/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net9.0": {
+      "Cake.BuildSystems.Module": {
+        "type": "Direct",
+        "requested": "[7.1.0, )",
+        "resolved": "7.1.0",
+        "contentHash": "/QO0f2S8qZKpO3a5xvXa1kLd0vhJFjC/7h4Qa3VfkY2YdRT0Mxwx9Ky5MbjE0rqGD79XSgT4lxDJU4N/speaQA=="
+      },
       "Cake.FileHelpers": {
         "type": "Direct",
         "requested": "[7.0.0, )",


### PR DESCRIPTION
Include Cake.BuildSystems.Module in the SharedBuild package's dependencies and enable support for Azure Pipelines and GitHub Actions implicitly in `UseSharedBuild()`.

This removes the need to explicitly install and load the modules in projects using the SharedBuild package.