### PR TITLE
feat: Make reporting of code coverage more consistent

### DIFF
--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -260,7 +260,7 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         // so it is shown in the "Code Coverage" Azure Pipelines Web UI
         //
 
-        var temporaryDirectory = context.CreateTemporaryDirectory();
+        using var temporaryDirectory = context.CreateTemporaryDirectory();
 
         context.Log.Verbose("Generating tailored HTML code coverage report for Azure Pipelines");
         context.ReportGenerator(
@@ -281,14 +281,16 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
             ReportDirectory = temporaryDirectory.Path
         });
 
+        using var stagingDirectory = context.CreateTemporaryDirectory();
+
+        context.CopyFileToDirectory(coverageReportPath, stagingDirectory.Path);
+        context.CopyDirectory(htmlReportPath, stagingDirectory.Path.Combine(htmlReportPath.GetDirectoryName()));
+
         //
         // Publish HTML report and coverage file as pipeline artifact to make it downloadable
         //
-        context.Log.Verbose($"Publishing merged code coverage file {coverageReportPath} as pipeline artifact");
-        context.AzurePipelines.Commands.UploadArtifact("", coverageReportPath, "CodeCoverage");
-
-        context.Log.Verbose($"Publishing code coverage HTML report as pipeline artifact");
-        context.AzurePipelines.Commands.UploadArtifact(htmlReportPath.GetDirectoryName(), htmlReportPath.ToString(), "CodeCoverage2");
+        context.Log.Verbose($"Publishing code coverage as pipeline artifact");
+        context.AzurePipelines.Commands.UploadArtifact("", stagingDirectory.ToString(), "CodeCoverage");
     }
 
     protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -287,17 +287,8 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         context.Log.Verbose($"Publishing merged code coverage file {coverageReportPath} as pipeline artifact");
         context.AzurePipelines.Commands.UploadArtifact("", coverageReportPath, "CodeCoverage");
 
-
         context.Log.Verbose($"Publishing code coverage HTML report as pipeline artifact");
-        foreach (var file in context.FileSystem.GetFilePaths(htmlReportPath, scope: SearchScope.Recursive))
-        {
-            // Compute the directory name of the file within the pipeline artifact being published
-            // The name consists of the name of the HTML report folder, plus the relative path of each file inside that directory
-
-            var folderName = ((DirectoryPath)htmlReportPath.GetDirectoryName()).Combine(htmlReportPath.GetRelativePath(file.GetDirectory())).Collapse().ToString();
-            context.Log.Debug($"Adding file '{file}' to pipeline artifact with folder name '{folderName}'");
-            context.AzurePipelines.Commands.UploadArtifact(folderName, file, "CodeCoverage");
-        }
+        context.AzurePipelines.Commands.UploadArtifact("", htmlReportPath.ToString(), "CodeCoverage2");
     }
 
     protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -9,10 +9,13 @@ using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Test;
 using Cake.Common.Tools.ReportGenerator;
+using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Frosting;
+using Grynwald.SharedBuild.Tools;
 using Grynwald.SharedBuild.Tools.TemporaryFiles;
+using Octokit;
 
 namespace Grynwald.SharedBuild.Tasks;
 
@@ -28,7 +31,7 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
 
         if (context.TestSettings.CollectCodeCoverage)
         {
-            await GenerateCoverageReportAsync(context);
+            await GenerateCodeCoverageOutputAsync(context);
         }
     }
 
@@ -136,84 +139,6 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         }
     }
 
-    private async Task GenerateCoverageReportAsync(IBuildContext context)
-    {
-        context.EnsureDirectoryDoesNotExist(context.Output.CodeCoverageReportDirectory, new() { Force = true, Recursive = true });
-
-        var coverageFiles = context.FileSystem.GetFilePaths(context.Output.TestResultsDirectory, "coverage.cobertura.xml", SearchScope.Recursive);
-
-        if (!coverageFiles.Any())
-            throw new Exception($"No coverage files found in '{context.Output.TestResultsDirectory}'");
-
-        context.Log.Information($"Found {coverageFiles.Count} coverage files");
-
-        //
-        // Generate Coverage Report and merged code coverage file
-        //
-        context.Log.Information("Merging coverage files");
-        var htmlReportType = context.AzurePipelines.IsActive
-            ? ReportGeneratorReportType.HtmlInline_AzurePipelines
-            : ReportGeneratorReportType.Html;
-
-        context.ReportGenerator(
-            reports: coverageFiles,
-            targetDir: context.Output.CodeCoverageReportDirectory,
-            settings: new ReportGeneratorSettings()
-            {
-                ReportTypes = [htmlReportType, ReportGeneratorReportType.Cobertura],
-                HistoryDirectory = context.Output.CodeCoverageHistoryDirectory
-            }
-        );
-
-        var coverageReportPath = context.Output.CodeCoverageReportDirectory.CombineWithFilePath("Cobertura.xml");
-
-        //
-        // Publish Code coverage report
-        //
-        if (context.AzurePipelines.IsActive)
-        {
-            PublishCodeCoverageToAzurePipelines(context, coverageReportPath);
-        }
-        else if (context.GitHubActions.IsActive)
-        {
-            await PublishCodeCoverageToGitHubActionsAsync(context, coverageReportPath);
-        }
-    }
-
-    protected virtual void PublishCodeCoverageToAzurePipelines(IBuildContext context, FilePath coverageReportPath)
-    {
-        context.Log.Information("Publishing Code Coverage Results to Azure Pipelines");
-        context.AzurePipelines.Commands.PublishCodeCoverage(new()
-        {
-            CodeCoverageTool = AzurePipelinesCodeCoverageToolType.Cobertura,
-            SummaryFileLocation = coverageReportPath,
-            ReportDirectory = context.Output.CodeCoverageReportDirectory
-        });
-    }
-
-    protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath)
-    {
-        context.Log.Information("Publishing Code Coverage Results to GitHub Actions");
-
-        using var temporaryDirectory = context.CreateTemporaryDirectory();
-
-        // Generate Markdown coverage report
-        context.ReportGenerator(
-            reports: [coverageReportPath],
-            targetDir: temporaryDirectory.Path.Combine("Report"),
-            settings: new ReportGeneratorSettings()
-            {
-                ReportTypes = [ReportGeneratorReportType.Html],
-                HistoryDirectory = context.Output.CodeCoverageHistoryDirectory,
-            }
-        );
-
-        context.CopyFileToDirectory(coverageReportPath, temporaryDirectory.Path);
-
-        // Publish coverage file and Summary as artifacts
-        await context.GitHubActions().Commands.UploadArtifact(temporaryDirectory.Path, "CodeCoverage");
-    }
-
     protected virtual IReadOnlyDictionary<FilePath, string> GetTestRunNames(IBuildContext context, IEnumerable<FilePath> testResultPaths)
     {
         var testRunNamer = new TestRunNamer(context.Log, context.Environment, context.FileSystem);
@@ -239,5 +164,154 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         }
 
         return testRunNames;
+    }
+
+    /// <summary>
+    /// Merges the individual code coverage reports from all test projects into a single coverage result file and generates a HTML report.
+    /// If the build is running in a CI system, the coverage is also published as pipeline artifact
+    /// </summary>
+    private async Task GenerateCodeCoverageOutputAsync(IBuildContext context)
+    {
+        var mergedCoverageResult = MergeCoverageFiles(context);
+
+        var htmlReportPath = GenerateCodeCoverageHtmlReport(context, mergedCoverageResult);
+
+        //
+        // Publish Code coverage report to CI artifacts if necessary
+        //
+        if (context.AzurePipelines.IsActive)
+        {
+            PublishCodeCoverageToAzurePipelines(context, mergedCoverageResult, htmlReportPath);
+        }
+        else if (context.GitHubActions.IsActive)
+        {
+            await PublishCodeCoverageToGitHubActionsAsync(context, mergedCoverageResult, htmlReportPath);
+        }
+    }
+
+    /// <summary>
+    /// Merges all code coverage outputs into a single Cobertura report file
+    /// </summary>
+    protected virtual FilePath MergeCoverageFiles(IBuildContext context)
+    {
+        var coverageFiles = context.FileSystem.GetFilePaths(context.Output.TestResultsDirectory, "coverage.cobertura.xml", SearchScope.Recursive);
+
+        if (!coverageFiles.Any())
+            throw new Exception($"No coverage files found in '{context.Output.TestResultsDirectory}'");
+
+        context.Log.Information($"Found {coverageFiles.Count} coverage files");
+
+        var mergedCoverageFilePath = context.Output.CodeCoverageOutputDirectory.CombineWithFilePath("Cobertura.xml");
+        context.EnsureFileDoesNotExist(mergedCoverageFilePath);
+
+        //
+        // Generate merged code coverage file
+        //
+        context.Log.Information("Merging coverage files");
+        context.ReportGenerator(
+            reports: coverageFiles,
+            targetDir: context.Output.CodeCoverageOutputDirectory,
+            settings: new ReportGeneratorSettings()
+            {
+                ReportTypes = [ReportGeneratorReportType.Cobertura],
+                HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
+            }
+        );
+
+        if (!context.FileExists(mergedCoverageFilePath))
+        {
+            throw new CakeException($"Failed to merge code coverage output files. Expected output file '{mergedCoverageFilePath}' does not exist after merging files");
+        }
+
+        return mergedCoverageFilePath;
+    }
+
+    /// <summary>
+    /// Generates a Code Coverage HTML report
+    /// </summary>
+    protected virtual DirectoryPath GenerateCodeCoverageHtmlReport(IBuildContext context, FilePath coverageFilePath)
+    {
+        var reportDirectory = context.Output.CodeCoverageOutputDirectory.Combine("Report");
+        context.Log.Information($"Generating code coverage HTML report to '{reportDirectory}'");
+        context.EnsureDirectoryDoesNotExist(reportDirectory);
+
+        context.ReportGenerator(
+            reports: [coverageFilePath],
+            targetDir: reportDirectory,
+            settings: new ReportGeneratorSettings()
+            {
+                ReportTypes = [ReportGeneratorReportType.Html],
+                HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
+            }
+        );
+
+        return reportDirectory;
+    }
+
+    private DirectoryPath GetCodeCoverageHistoryDirectory(IBuildContext context) => context.Output.CodeCoverageOutputDirectory.Combine("History");
+
+
+    protected virtual void PublishCodeCoverageToAzurePipelines(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)
+    {
+        context.Log.Information("Publishing Code Coverage Results to Azure Pipelines");
+
+        //
+        // Generate a version of the HTML report tailored for Azure Pipelines and publish it as code coverage
+        // so it is shown in the "Code Coverage" Azure Pipelines Web UI
+        //
+
+        var temporaryDirectory = context.CreateTemporaryDirectory();
+
+        context.Log.Verbose("Generating tailored HTML code coverage report for Azure Pipelines");
+        context.ReportGenerator(
+            reports: [coverageReportPath],
+            targetDir: temporaryDirectory.Path,
+            settings: new ReportGeneratorSettings()
+            {
+                ReportTypes = [ReportGeneratorReportType.HtmlInline_AzurePipelines],
+                HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
+            }
+        );
+
+        context.Log.Verbose("Publishing code coverage to Azure Pipelines Web UI");
+        context.AzurePipelines.Commands.PublishCodeCoverage(new()
+        {
+            CodeCoverageTool = AzurePipelinesCodeCoverageToolType.Cobertura,
+            SummaryFileLocation = coverageReportPath,
+            ReportDirectory = temporaryDirectory.Path
+        });
+
+        //
+        // Publish HTML report and coverage file as pipeline artifact to make it downloadable
+        //
+        context.Log.Verbose($"Publishing merged code coverage file {coverageReportPath} as pipeline artifact");
+        context.AzurePipelines.Commands.UploadArtifact("", coverageReportPath, "CodeCoverage");
+
+
+        context.Log.Verbose($"Publishing code coverage HTML report as pipeline artifact");
+        foreach (var file in context.FileSystem.GetFilePaths(htmlReportPath, scope: SearchScope.Recursive))
+        {
+            // Compute the directory name of the file within the pipeline artifact being published
+            // The name consists of the name of the HTML report folder, plus the relative path of each file inside that directory
+
+            var folderName = ((DirectoryPath)htmlReportPath.GetDirectoryName()).Combine(htmlReportPath.GetRelativePath(file.GetDirectory())).ToString();
+            context.Log.Debug($"Adding file '{file}' to pipeline artifact with folder name '{folderName}'");
+            context.AzurePipelines.Commands.UploadArtifact(folderName, file, "CodeCoverage");
+        }
+    }
+
+    protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)
+    {
+        context.Log.Information("Publishing Code Coverage Results to GitHub Actions");
+
+        // GitHUb Actions only allows artifact uploads once for each name
+        // => Copy all files together into a temporary directory and publish that directory
+        using var temporaryDirectory = context.CreateTemporaryDirectory();
+
+        context.CopyFileToDirectory(coverageReportPath, temporaryDirectory.Path);
+        context.CopyDirectory(htmlReportPath, temporaryDirectory.Path.Combine(htmlReportPath.GetDirectoryName()));
+
+        // Publish coverage file and Summary as artifacts
+        await context.GitHubActions().Commands.UploadArtifact(temporaryDirectory.Path, "CodeCoverage");
     }
 }

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -288,7 +288,7 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         context.AzurePipelines.Commands.UploadArtifact("", coverageReportPath, "CodeCoverage");
 
         context.Log.Verbose($"Publishing code coverage HTML report as pipeline artifact");
-        context.AzurePipelines.Commands.UploadArtifact("", htmlReportPath.ToString(), "CodeCoverage2");
+        context.AzurePipelines.Commands.UploadArtifact(htmlReportPath.GetDirectoryName(), htmlReportPath.ToString(), "CodeCoverage2");
     }
 
     protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Cake.Common.Build;
@@ -15,7 +14,6 @@ using Cake.Core.IO;
 using Cake.Frosting;
 using Grynwald.SharedBuild.Tools;
 using Grynwald.SharedBuild.Tools.TemporaryFiles;
-using Octokit;
 
 namespace Grynwald.SharedBuild.Tasks;
 

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -257,27 +257,25 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         // Generate a version of the HTML report tailored for Azure Pipelines and publish it as code coverage
         // so it is shown in the "Code Coverage" Azure Pipelines Web UI
         //
-        using (var temporaryDirectory1 = context.CreateTemporaryDirectory())
-        {
-            context.Log.Verbose("Generating tailored HTML code coverage report for Azure Pipelines");
-            context.ReportGenerator(
-                reports: [coverageReportPath],
-                targetDir: temporaryDirectory1.Path,
-                settings: new ReportGeneratorSettings()
-                {
-                    ReportTypes = [ReportGeneratorReportType.HtmlInline_AzurePipelines],
-                    HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
-                }
-            );
-
-            context.Log.Verbose("Publishing code coverage to Azure Pipelines Web UI");
-            context.AzurePipelines.Commands.PublishCodeCoverage(new()
+        var azurePipelinesHtmlReportDirectory = context.AzurePipelines.Environment.Build.ArtifactStagingDirectory.Combine($"{Guid.NewGuid():n}");
+        context.Log.Verbose("Generating tailored HTML code coverage report for Azure Pipelines");
+        context.ReportGenerator(
+            reports: [coverageReportPath],
+            targetDir: azurePipelinesHtmlReportDirectory,
+            settings: new ReportGeneratorSettings()
             {
-                CodeCoverageTool = AzurePipelinesCodeCoverageToolType.Cobertura,
-                SummaryFileLocation = coverageReportPath,
-                ReportDirectory = temporaryDirectory1.Path
-            });
-        }
+                ReportTypes = [ReportGeneratorReportType.HtmlInline_AzurePipelines],
+                HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
+            }
+        );
+
+        context.Log.Verbose("Publishing code coverage to Azure Pipelines Web UI");
+        context.AzurePipelines.Commands.PublishCodeCoverage(new()
+        {
+            CodeCoverageTool = AzurePipelinesCodeCoverageToolType.Cobertura,
+            SummaryFileLocation = coverageReportPath,
+            ReportDirectory = azurePipelinesHtmlReportDirectory
+        });
 
         //
         // Publish HTML report and coverage report as pipeline artifact to make it downloadable

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -290,7 +290,7 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         // Publish HTML report and coverage file as pipeline artifact to make it downloadable
         //
         context.Log.Verbose($"Publishing code coverage as pipeline artifact");
-        context.AzurePipelines.Commands.UploadArtifact("", stagingDirectory.ToString(), "CodeCoverage");
+        context.AzurePipelines.Commands.UploadArtifact("", stagingDirectory.Path.ToString(), "CodeCoverage");
     }
 
     protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -259,45 +259,47 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
         // Generate a version of the HTML report tailored for Azure Pipelines and publish it as code coverage
         // so it is shown in the "Code Coverage" Azure Pipelines Web UI
         //
-
-        using var temporaryDirectory = context.CreateTemporaryDirectory();
-
-        context.Log.Verbose("Generating tailored HTML code coverage report for Azure Pipelines");
-        context.ReportGenerator(
-            reports: [coverageReportPath],
-            targetDir: temporaryDirectory.Path,
-            settings: new ReportGeneratorSettings()
-            {
-                ReportTypes = [ReportGeneratorReportType.HtmlInline_AzurePipelines],
-                HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
-            }
-        );
-
-        context.Log.Verbose("Publishing code coverage to Azure Pipelines Web UI");
-        context.AzurePipelines.Commands.PublishCodeCoverage(new()
+        using (var temporaryDirectory1 = context.CreateTemporaryDirectory())
         {
-            CodeCoverageTool = AzurePipelinesCodeCoverageToolType.Cobertura,
-            SummaryFileLocation = coverageReportPath,
-            ReportDirectory = temporaryDirectory.Path
-        });
+            context.Log.Verbose("Generating tailored HTML code coverage report for Azure Pipelines");
+            context.ReportGenerator(
+                reports: [coverageReportPath],
+                targetDir: temporaryDirectory1.Path,
+                settings: new ReportGeneratorSettings()
+                {
+                    ReportTypes = [ReportGeneratorReportType.HtmlInline_AzurePipelines],
+                    HistoryDirectory = GetCodeCoverageHistoryDirectory(context)
+                }
+            );
 
-        using var stagingDirectory = context.CreateTemporaryDirectory();
-
-        context.CopyFileToDirectory(coverageReportPath, stagingDirectory.Path);
-        context.CopyDirectory(htmlReportPath, stagingDirectory.Path.Combine(htmlReportPath.GetDirectoryName()));
+            context.Log.Verbose("Publishing code coverage to Azure Pipelines Web UI");
+            context.AzurePipelines.Commands.PublishCodeCoverage(new()
+            {
+                CodeCoverageTool = AzurePipelinesCodeCoverageToolType.Cobertura,
+                SummaryFileLocation = coverageReportPath,
+                ReportDirectory = temporaryDirectory1.Path
+            });
+        }
 
         //
-        // Publish HTML report and coverage file as pipeline artifact to make it downloadable
+        // Publish HTML report and coverage report as pipeline artifact to make it downloadable
         //
+
+        var artifactStagingDirectory = context.AzurePipelines.Environment.Build.ArtifactStagingDirectory.Combine("CodeCoverage");
+        context.EnsureDirectoryDoesNotExist(artifactStagingDirectory);
+        context.EnsureDirectoryExists(artifactStagingDirectory);
+
+        context.CopyFileToDirectory(coverageReportPath, artifactStagingDirectory);
+        context.CopyDirectory(htmlReportPath, artifactStagingDirectory.Combine(htmlReportPath.GetDirectoryName()));
         context.Log.Verbose($"Publishing code coverage as pipeline artifact");
-        context.AzurePipelines.Commands.UploadArtifact("", stagingDirectory.Path.ToString(), "CodeCoverage");
+        context.AzurePipelines.Commands.UploadArtifact("", artifactStagingDirectory.ToString(), "CodeCoverage");
     }
 
     protected virtual async Task PublishCodeCoverageToGitHubActionsAsync(IBuildContext context, FilePath coverageReportPath, DirectoryPath htmlReportPath)
     {
         context.Log.Information("Publishing Code Coverage Results to GitHub Actions");
 
-        // GitHUb Actions only allows artifact uploads once for each name
+        // GitHub Actions only allows artifact uploads once for each name
         // => Copy all files together into a temporary directory and publish that directory
         using var temporaryDirectory = context.CreateTemporaryDirectory();
 

--- a/src/SharedBuild/Tasks/TestTask.cs
+++ b/src/SharedBuild/Tasks/TestTask.cs
@@ -294,7 +294,7 @@ public class TestTask : AsyncFrostingTask<IBuildContext>
             // Compute the directory name of the file within the pipeline artifact being published
             // The name consists of the name of the HTML report folder, plus the relative path of each file inside that directory
 
-            var folderName = ((DirectoryPath)htmlReportPath.GetDirectoryName()).Combine(htmlReportPath.GetRelativePath(file.GetDirectory())).ToString();
+            var folderName = ((DirectoryPath)htmlReportPath.GetDirectoryName()).Combine(htmlReportPath.GetRelativePath(file.GetDirectory())).Collapse().ToString();
             context.Log.Debug($"Adding file '{file}' to pipeline artifact with folder name '{folderName}'");
             context.AzurePipelines.Commands.UploadArtifact(folderName, file, "CodeCoverage");
         }

--- a/src/SharedBuild/Tools/FileAliases.cs
+++ b/src/SharedBuild/Tools/FileAliases.cs
@@ -1,0 +1,16 @@
+﻿using Cake.Core;
+using Cake.Core.IO;
+
+namespace Grynwald.SharedBuild.Tools;
+
+public static class FileAliases
+{
+    public static void EnsureFileDoesNotExist(this ICakeContext context, FilePath path)
+    {
+        var file = context.FileSystem.GetFile(path);
+        if (file.Exists)
+        {
+            file.Delete();
+        }
+    }
+}

--- a/src/SharedBuild/_Context/IOutputContext.cs
+++ b/src/SharedBuild/_Context/IOutputContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Cake.Core.IO;
 
 namespace Grynwald.SharedBuild;
@@ -26,15 +27,9 @@ public interface IOutputContext : IPrintableObject
     DirectoryPath TestResultsDirectory { get; }
 
     /// <summary>
-    /// Gets the output path for code coverage reports
+    /// Gets the output path for the code coverage report
     /// </summary>
-    DirectoryPath CodeCoverageReportDirectory { get; }
-
-    /// <summary>
-    /// Gets the output path for code coverage history files
-    /// (used by Report Generator to show differences in code coverage between different runs)
-    /// </summary>
-    DirectoryPath CodeCoverageHistoryDirectory { get; }
+    DirectoryPath CodeCoverageOutputDirectory { get; }
 
     /// <summary>
     /// Gets all NuGet package files in the packages output directory

--- a/src/SharedBuild/_Context/_Default/DefaultOutputContext.cs
+++ b/src/SharedBuild/_Context/_Default/DefaultOutputContext.cs
@@ -28,10 +28,9 @@ public class DefaultOutputContext(DefaultBuildContext context) : IOutputContext
     public virtual DirectoryPath TestResultsDirectory => BinariesDirectory.Combine(m_Context.BuildSettings.Configuration).Combine("TestResults");
 
     /// <inheritdoc />
-    public virtual DirectoryPath CodeCoverageReportDirectory => BinariesDirectory.Combine(m_Context.BuildSettings.Configuration).Combine("CodeCoverage").Combine("Report");
+    public virtual DirectoryPath CodeCoverageOutputDirectory => BinariesDirectory.Combine(m_Context.BuildSettings.Configuration).Combine("CodeCoverage");
 
-    /// <inheritdoc />
-    public virtual DirectoryPath CodeCoverageHistoryDirectory => BinariesDirectory.Combine(m_Context.BuildSettings.Configuration).Combine("CodeCoverage").Combine("History");
+
 
     /// <inheritdoc />
     public virtual FilePath ChangeLogFile => BinariesDirectory.CombineWithFilePath("changelog.md");
@@ -46,8 +45,7 @@ public class DefaultOutputContext(DefaultBuildContext context) : IOutputContext
         log.Information($"{nameof(BinariesDirectory)}: {BinariesDirectory.FullPath}");
         log.Information($"{nameof(PackagesDirectory)}: {PackagesDirectory.FullPath}");
         log.Information($"{nameof(TestResultsDirectory)}: {TestResultsDirectory.FullPath}");
-        log.Information($"{nameof(CodeCoverageReportDirectory)}: {CodeCoverageReportDirectory.FullPath}");
-        log.Information($"{nameof(CodeCoverageHistoryDirectory)}: {CodeCoverageHistoryDirectory.FullPath}");
+        log.Information($"{nameof(CodeCoverageOutputDirectory)}: {CodeCoverageOutputDirectory.FullPath}");
         log.Information($"{nameof(ChangeLogFile)}: {ChangeLogFile.FullPath}");
     }
 }


### PR DESCRIPTION
Adjust how code coverage reports are generated and make behavior consistent between local and CI builds

- The combined coverage data (Cobertura.xml) will be placed directly in the code coverage output directory
- The "Report" directory will always contain a HTML report (no longer a Azure Pipelines specific report when running on Azure Pipelines.
- The HTML report as well as the Cobertura.xml is now published as pipeline artifact on both Azure Pipelines and GitHub Actions
- The Azure Pipelines-specific HTML report that is shown in the web UI is now generated in a temporary directory (and only when publishing results to Azure Pipelines)
